### PR TITLE
Fallback to localhost redis-server on DEV settings

### DIFF
--- a/pythonie/pythonie/settings/configure.py
+++ b/pythonie/pythonie/settings/configure.py
@@ -16,6 +16,8 @@ def configure_redis(redis_url, test=False):
 
         url = urlparse(redis_url)
         log.info('Redis configured with redis_url: %s' % redis_url)
-        return redis.Redis(host=url.hostname, port=url.port, password=url.password)
+        return redis.Redis(host=url.hostname,
+                           port=url.port,
+                           password=url.password)
 
     log.warn('Redis not configured')

--- a/pythonie/pythonie/settings/dev.py
+++ b/pythonie/pythonie/settings/dev.py
@@ -17,7 +17,8 @@ DATABASES = {
     }
 }
 
-REDIS_URL = os.environ.get('REDISCLOUD_URL')
+# assumes no DEV:REDISCLOUD_URL available but that redis-server running locally
+REDIS_URL = os.environ.get('REDISCLOUD_URL', '//127.0.0.1:6379')
 REDIS = configure_redis(REDIS_URL)
 
 # CACHES = {


### PR DESCRIPTION
DEV instances fail on Redis.get attempts as there is no Heroku REDISCLOUD_URL envvar available.

This assumes that the user has redis-server running on their machine.