### PR TITLE
Load web font in document head to prevent flash of incorrectly styled content

### DIFF
--- a/pythonie/core/static/css/style.css
+++ b/pythonie/core/static/css/style.css
@@ -6,26 +6,25 @@ body {
     font-style: normal;
     font-weight: 300; /* Bree Serif: 700 (bold), 400 (regular), 300 (light), 200 (thin); */
 }
+.wf-loading {
+    visibility: hidden;
+}
 
 /* HEADER */
-
 h2, h3, h4, h5, h6 {
     font-family: "bree", sans-serif;
     font-style: normal;
     font-weight: 400; /* Bree: 700 (bold), 400 (regular), 300 (light), 200 (thin) */
 }
-
 h1 {
     font-family: "bree", sans-serif;
     font-style: normal;
     font-weight: 700;
 }
-
 .list-group img {
     width: 100%;
     max-width: 183px;
 }
-
 #header h1 {
     font-size: 32pt;
     text-align: left;
@@ -33,44 +32,35 @@ h1 {
     white-space: normal;
     color: white;
 }
-
 #header h1 #pyhead {
     color: #336600;
 }
-
 #header h1 #iehead {
     color: #339900;
 }
-
 #header h1 #yearhead {
     color: #66cc33;
 }
-
 #header .well {
     margin-top: 15px;
 }
 
 /* END HEADER */
-
 .sponsor-list .sponsor img {
     max-width: 140px;
     max-height: 100px;
 }
-
 .sponsor-list .sponsor {
     padding-bottom: 0.5em
 }
-
 .sponsor-list {
     list-style: none;
     padding-left: 0em;
 }
-
 .sponsor .logo {
     float: left;
     margin-right: 0.5em
 }
-
 .blog .blog-post-link {
     font-family: "bree", sans-serif;
     font-style: normal;

--- a/pythonie/core/templates/base.html
+++ b/pythonie/core/templates/base.html
@@ -17,6 +17,10 @@
     <meta name="description" content=""/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
+     <script type="text/javascript" src="//use.typekit.net/qgj1xay.js"></script>
+     <script type="text/javascript">try{Typekit.load({async: false});}catch(e){}</script>
+
+
     {% compress css %}
         <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
         <link rel="stylesheet" href="{% static 'css/style.css' %}">
@@ -46,8 +50,6 @@
     <script src='https://js.tito.io/v1' async></script>
     <script src="https://code.jquery.com/jquery.js"></script>
     <script src="{% static 'js/bootstrap.min.js' %}"></script>
-    <script type="text/javascript" src="//use.typekit.net/qgj1xay.js"></script>
-    <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
When loading the Typekit font at the bottom of <body/>, the font appearance
changes noticeably when the page is first loaded and the Typekit font
has not been cached previously.
Loading the font at the top increases the time until page content is
shown (when cache empty), but reduces irritation.