### PR TITLE
#58: Wrap 404 page content in a container div

### DIFF
--- a/pythonie/core/templates/404.html
+++ b/pythonie/core/templates/404.html
@@ -3,7 +3,9 @@
 {% block body_class %}template-404{% endblock %}
 
 {% block content %}
-    <h1>Page not found</h1>
+    <div class="container">
+        <h1>Page not found</h1>
 
-    <h2>Sorry, this page could not be found.</h2>
+        <h2>Sorry, this page could not be found.</h2>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Fix for issue #58 . Added a container div around the 404 page content for to keep content inside container, and consistent with other pages.