### PR TITLE
Pillow version broken on Windows 10.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -31,7 +31,7 @@ lxml==3.7.3
 mccabe==0.5.0
 olefile==0.44
 packaging==16.8
-Pillow==4.1.0
+Pillow==4.1.1
 pycodestyle==2.0.0
 pyflakes==1.2.3
 pyparsing==2.2.0


### PR DESCRIPTION
Pillow version 4.1.0 has some outstanding issues when running on Windows that were fixed in 4.1.1.