### PR TITLE
Removed three fields from the Meetups schema as no longer in API response

### DIFF
--- a/pythonie/meetups/schema.py
+++ b/pythonie/meetups/schema.py
@@ -50,14 +50,14 @@ class Meetups(colander.MappingSchema):
 
             @colander.instantiate(missing=colander.drop)
             class venue(colander.MappingSchema):
-                city = colander.SchemaNode(colander.String())
+                # city = colander.SchemaNode(colander.String())
                 lon = colander.SchemaNode(colander.Float())
                 repinned = colander.SchemaNode(colander.Boolean())
                 lat = colander.SchemaNode(colander.Float())
                 id = colander.SchemaNode(colander.Float())
                 name = colander.SchemaNode(colander.String())
-                address_1 = colander.SchemaNode(colander.String())
-                country = colander.SchemaNode(colander.String())
+                # address_1 = colander.SchemaNode(colander.String())
+                # country = colander.SchemaNode(colander.String())
 
             name = colander.SchemaNode(colander.String())
             headcount = colander.SchemaNode(colander.Integer())


### PR DESCRIPTION
I think this is the reason that the Meetups are not updating. These three fields are no longer in the Meetups API response so it is breaking the schema validation. By commenting out, then the update task can complete and the meetups are saved in Django for display on the website.