### PR TITLE
Update Django to 3.2.25

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ click==8.1.7
     # via black
 coverage==7.5.3
     # via -r requirements/dev.in
-django==3.2.18
+django==3.2.25
     # via
     #   -c requirements/main.txt
     #   django-debug-toolbar

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -1,6 +1,6 @@
 # main.in
 Delorean
-Django==3.2.18
+Django==3.2.25
 Willow
 boto3
 colander

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -28,7 +28,7 @@ dj-database-url==2.2.0
     # via -r requirements/main.in
 dj-static==0.0.6
     # via -r requirements/main.in
-django==3.2.18
+django==3.2.25
     # via
     #   -r requirements/main.in
     #   dj-database-url


### PR DESCRIPTION
This PR is for the last upgrade of Django 3.2