### PR TITLE
Exclude sponsors from the HomePage copy 

### DIFF
--- a/pythonie/core/models.py
+++ b/pythonie/core/models.py
@@ -104,6 +104,7 @@ class HomePageSponsorRelationship(models.Model):
 
 
 class HomePage(Page, MeetupMixin, SponsorMixin):
+    exclude_fields_in_copy = ['sponsors']
     subpage_types = [
         "HomePage",
         "SimplePage",


### PR DESCRIPTION
Wagtails allows to exclude fields in the copy process, and we use it to exclude the sponsors.