### PR TITLE
🚀 feat: upgrade to Django 6.0

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,7 +24,7 @@ defusedxml==0.7.1
     # via
     #   -c requirements/main.txt
     #   py-serializable
-django==5.2.9
+django==6.0
     # via
     #   -c requirements/main.txt
     #   django-debug-toolbar

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -32,7 +32,7 @@ dj-database-url==3.0.1
     # via -r requirements/main.in
 dj-static==0.0.6
     # via -r requirements/main.in
-django==5.2.9
+django==6.0
     # via
     #   -r requirements/main.in
     #   dj-database-url


### PR DESCRIPTION
## Summary

This PR upgrades Django from version 5.2.9 to 6.0, which was released on December 3, 2025.

## Changes

- **requirements/main.txt**: Django 5.2.9 → 6.0
- **requirements/dev.txt**: Django 5.2.9 → 6.0

## Compatibility

- ✅ Django 6.0 is supported by Wagtail 7.2.x ([wagtail/wagtail#13622](https://github.com/wagtail/wagtail/pull/13622))
- ✅ All 33 tests pass successfully
- ✅ No breaking changes detected

## Testing

```bash
task tests
```

All 33 tests pass:
```
Ran 33 tests in 0.706s

OK
```

## References

- [Django 6.0 Release Notes](https://docs.djangoproject.com/en/6.0/releases/6.0/)
- [Wagtail Django 6.0 Support PR](https://github.com/wagtail/wagtail/pull/13622)

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)