### PR TITLE
🔧 chore: update Python dependencies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,9 +16,9 @@ charset-normalizer==3.4.4
     # via
     #   -c requirements/main.txt
     #   requests
-coverage==7.12.0
+coverage==7.13.1
     # via -r requirements/dev.in
-cyclonedx-python-lib==9.1.0
+cyclonedx-python-lib==11.6.0
     # via pip-audit
 defusedxml==0.7.1
     # via
@@ -33,9 +33,9 @@ django-debug-toolbar==6.1.0
     # via -r requirements/dev.in
 factory-boy==3.3.3
     # via -r requirements/dev.in
-faker==39.0.0
+faker==40.1.0
     # via factory-boy
-fakeredis==2.32.1
+fakeredis==2.33.0
     # via -r requirements/dev.in
 filelock==3.20.1
     # via cachecontrol
@@ -69,19 +69,19 @@ pip==25.3
     #   pipdeptree
 pip-api==0.0.34
     # via pip-audit
-pip-audit==2.9.0
+pip-audit==2.10.0
     # via -r requirements/dev.in
 pip-requirements-parser==32.0.1
     # via pip-audit
 pipdeptree==2.30.0
     # via -r requirements/dev.in
-platformdirs==4.5.0
+platformdirs==4.5.1
     # via pip-audit
 py-serializable==2.1.0
     # via cyclonedx-python-lib
 pygments==2.19.2
     # via rich
-pyparsing==3.2.5
+pyparsing==3.3.1
     # via pip-requirements-parser
 redis==7.1.0
     # via
@@ -94,20 +94,22 @@ requests==2.32.5
     #   pip-audit
 rich==14.2.0
     # via pip-audit
-ruff==0.14.7
+ruff==0.14.10
     # via -r requirements/dev.in
 sortedcontainers==2.4.0
     # via
     #   cyclonedx-python-lib
     #   fakeredis
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via
     #   -c requirements/main.txt
     #   django
     #   django-debug-toolbar
-toml==0.10.2
+tomli==2.3.0
     # via pip-audit
-tzdata==2025.2
+tomli-w==1.2.0
+    # via pip-audit
+tzdata==2025.3
     # via
     #   -c requirements/main.txt
     #   faker
@@ -115,5 +117,5 @@ urllib3==2.6.2
     # via
     #   -c requirements/main.txt
     #   requests
-uv==0.9.13
+uv==0.9.20
     # via -r requirements/dev.in

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -8,11 +8,11 @@ asgiref==3.11.0
     # via django
 babel==2.17.0
     # via delorean
-beautifulsoup4==4.14.2
+beautifulsoup4==4.14.3
     # via wagtail
-boto3==1.41.5
+boto3==1.42.18
     # via -r requirements/main.in
-botocore==1.41.5
+botocore==1.42.18
     # via
     #   boto3
     #   s3transfer
@@ -63,7 +63,7 @@ django-filter==25.2
     # via wagtail
 django-libsass==0.9
     # via -r requirements/main.in
-django-modelcluster==6.4
+django-modelcluster==6.4.1
     # via
     #   -r requirements/main.in
     #   wagtail
@@ -71,7 +71,7 @@ django-permissionedforms==0.1
     # via wagtail
 django-storages==1.14.6
     # via -r requirements/main.in
-django-stubs-ext==5.2.7
+django-stubs-ext==5.2.8
     # via django-tasks
 django-taggit==6.1.0
     # via
@@ -81,7 +81,7 @@ django-tasks==0.9.0
     # via
     #   modelsearch
     #   wagtail
-django-treebeard==4.7.1
+django-treebeard==4.8.0
     # via wagtail
 djangorestframework==3.16.1
     # via wagtail
@@ -93,7 +93,7 @@ filetype==1.2.0
     # via willow
 gunicorn==23.0.0
     # via -r requirements/main.in
-humanize==4.14.0
+humanize==4.15.0
     # via delorean
 idna==3.11
     # via requests
@@ -109,7 +109,7 @@ libsass==0.23.0
     # via django-libsass
 modelsearch==1.1.1
     # via wagtail
-numpy==2.3.5
+numpy==2.4.0
     # via pandas
 openpyxl==3.1.5
     # via wagtail
@@ -152,13 +152,13 @@ requests==2.32.5
     #   wagtail
 rjsmin==1.2.5
     # via django-compressor
-s3transfer==0.15.0
+s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-soupsieve==2.8
+soupsieve==2.8.1
     # via beautifulsoup4
-sqlparse==0.5.4
+sqlparse==0.5.5
     # via django
 static3==0.7.0
     # via dj-static
@@ -171,13 +171,12 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   django-stubs-ext
     #   django-tasks
-    #   psycopg
     #   pydantic
     #   pydantic-core
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.2
+tzdata==2025.3
     # via pandas
 tzlocal==5.3.1
     # via delorean


### PR DESCRIPTION
## Summary

Updates Python dependencies to their latest versions using `task dependencies:upgrade`.

## Main Dependency Updates

- **boto3**: 1.41.5 → 1.42.18 (AWS SDK)
- **numpy**: 2.3.5 → 2.4.0
- **django-treebeard**: 4.7.1 → 4.8.0
- **beautifulsoup4**: 4.14.2 → 4.14.3
- Plus 8 other minor updates

## Dev Dependency Updates

- **uv**: 0.9.13 → 0.9.20 (package manager)
- **ruff**: 0.14.7 → 0.14.10 (linter/formatter)
- **cyclonedx-python-lib**: 9.1.0 → 11.6.0 (major version bump)
- **toml → tomli**: Package migration
- Plus 9 other minor updates

## Test Plan

- [ ] CI tests pass
- [ ] Local development environment works
- [ ] No breaking changes in updated packages

## References

Related to issue #184 (Dependabot research)

🤖 Generated with [Claude Code](https://claude.com/claude-code)