### PR TITLE
fix: Add ruff:noqa and os import to settings files

### DIFF
--- a/pythonie/pythonie/settings/dev.py
+++ b/pythonie/pythonie/settings/dev.py
@@ -1,6 +1,8 @@
+# ruff: noqa
+import os
 from pythonie.settings.configure import configure_redis
 
-from .base import *  # flake8: noqa
+from .base import *
 
 DEBUG = True
 

--- a/pythonie/pythonie/settings/production.py
+++ b/pythonie/pythonie/settings/production.py
@@ -1,6 +1,8 @@
+# ruff: noqa
+import os
 from pythonie.settings.configure import configure_redis
 
-from .base import *  # flake8: noqa
+from .base import *
 
 # Disable debug mode
 DEBUG = False

--- a/pythonie/pythonie/settings/tests.py
+++ b/pythonie/pythonie/settings/tests.py
@@ -1,6 +1,8 @@
+# ruff: noqa
+import os
 from pythonie.settings.configure import configure_redis
 
-from .base import *  # flake8: noqa
+from .base import *
 
 DEBUG = True
 


### PR DESCRIPTION
## Summary
- Add `ruff: noqa` directive to settings files to suppress wildcard import warnings
- Add explicit `os` import to ensure availability in all settings modules
- Update flake8 noqa comments to ruff format

## Test plan
- [x] Verify ruff linting passes: `task code:check`
- [x] Verify Django settings load correctly: `python pythonie/manage.py check --settings=pythonie.settings.dev`
- [x] Verify tests still pass: `task tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)