### PR TITLE
chore: update Python dependencies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.4.4
     # via
     #   -c requirements/main.txt
     #   requests
-coverage==7.13.1
+coverage==7.13.2
     # via -r requirements/dev.in
 cyclonedx-python-lib==11.6.0
     # via pip-audit
@@ -49,7 +49,7 @@ django==6.0.1
     #   model-mommy
     #   modelsearch
     #   wagtail
-django-debug-toolbar==6.1.0
+django-debug-toolbar==6.2.0
     # via -r requirements/dev.in
 django-filter==25.2
     # via
@@ -63,7 +63,7 @@ django-permissionedforms==0.1
     # via
     #   -c requirements/main.txt
     #   wagtail
-django-stubs-ext==5.2.8
+django-stubs-ext==5.2.9
     # via
     #   -c requirements/main.txt
     #   django-tasks
@@ -94,7 +94,7 @@ et-xmlfile==2.0.0
     #   openpyxl
 factory-boy==3.3.3
     # via wagtail-factories
-faker==40.1.0
+faker==40.1.2
     # via factory-boy
 fakeredis==2.33.0
     # via -r requirements/dev.in
@@ -134,7 +134,7 @@ openpyxl==3.1.5
     #   wagtail
 packageurl-python==0.17.6
     # via cyclonedx-python-lib
-packaging==25.0
+packaging==26.0
     # via
     #   -c requirements/main.txt
     #   pip-audit
@@ -145,11 +145,11 @@ pillow==12.1.0
     #   -c requirements/main.txt
     #   pillow-heif
     #   wagtail
-pillow-heif==1.1.1
+pillow-heif==1.2.0
     # via
     #   -c requirements/main.txt
     #   willow
-pip==25.3
+pip==26.0
     # via
     #   pip-api
     #   pipdeptree
@@ -167,7 +167,7 @@ py-serializable==2.1.0
     # via cyclonedx-python-lib
 pygments==2.19.2
     # via rich
-pyparsing==3.3.1
+pyparsing==3.3.2
     # via pip-requirements-parser
 redis==7.1.0
     # via
@@ -179,15 +179,15 @@ requests==2.32.5
     #   cachecontrol
     #   pip-audit
     #   wagtail
-rich==14.2.0
+rich==14.3.2
     # via pip-audit
-ruff==0.14.11
+ruff==0.14.14
     # via -r requirements/dev.in
 sortedcontainers==2.4.0
     # via
     #   cyclonedx-python-lib
     #   fakeredis
-soupsieve==2.8.1
+soupsieve==2.8.3
     # via
     #   -c requirements/main.txt
     #   beautifulsoup4
@@ -200,7 +200,7 @@ telepath==0.3.1
     # via
     #   -c requirements/main.txt
     #   wagtail
-tomli==2.3.0
+tomli==2.4.0
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
@@ -210,15 +210,11 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   django-stubs-ext
     #   django-tasks
-tzdata==2025.3
-    # via
-    #   -c requirements/main.txt
-    #   faker
 urllib3==2.6.3
     # via
     #   -c requirements/main.txt
     #   requests
-uv==0.9.24
+uv==0.9.28
     # via -r requirements/dev.in
 wagtail==7.2.1
     # via

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -6,13 +6,13 @@ anyascii==0.3.3
     # via wagtail
 asgiref==3.11.0
     # via django
-babel==2.17.0
+babel==2.18.0
     # via delorean
 beautifulsoup4==4.14.3
     # via wagtail
-boto3==1.42.25
+boto3==1.42.40
     # via -r requirements/main.in
-botocore==1.42.25
+botocore==1.42.40
     # via
     #   boto3
     #   s3transfer
@@ -71,7 +71,7 @@ django-permissionedforms==0.1
     # via wagtail
 django-storages==1.14.6
     # via -r requirements/main.in
-django-stubs-ext==5.2.8
+django-stubs-ext==5.2.9
     # via django-tasks
 django-taggit==6.1.0
     # via
@@ -91,7 +91,7 @@ et-xmlfile==2.0.0
     # via openpyxl
 filetype==1.2.0
     # via willow
-gunicorn==23.0.0
+gunicorn==25.0.1
     # via -r requirements/main.in
 humanize==4.15.0
     # via delorean
@@ -99,7 +99,7 @@ idna==3.11
     # via requests
 iso8601==2.1.0
     # via colander
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
@@ -109,19 +109,19 @@ libsass==0.23.0
     # via django-libsass
 modelsearch==1.1.1
     # via wagtail
-numpy==2.4.1
+numpy==2.4.2
     # via pandas
 openpyxl==3.1.5
     # via wagtail
-packaging==25.0
+packaging==26.0
     # via gunicorn
-pandas==2.3.3
+pandas==3.0.0
     # via -r requirements/main.in
 pillow==12.1.0
     # via
     #   pillow-heif
     #   wagtail
-pillow-heif==1.1.1
+pillow-heif==1.2.0
     # via willow
 psycopg==3.3.2
     # via -r requirements/main.in
@@ -141,7 +141,6 @@ pytz==2025.2
     # via
     #   -r requirements/main.in
     #   delorean
-    #   pandas
 rcssmin==1.2.2
     # via django-compressor
 redis==7.1.0
@@ -156,7 +155,7 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-soupsieve==2.8.1
+soupsieve==2.8.3
     # via beautifulsoup4
 sqlparse==0.5.5
     # via django
@@ -176,8 +175,6 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.3
-    # via pandas
 tzlocal==5.3.1
     # via delorean
 urllib3==2.6.3


### PR DESCRIPTION
## Summary
- Update Python dependencies to their latest compatible versions across development and main requirements

## Key Updates

### Major Version Upgrades
- **pandas**: 2.3.3 → 3.0.0 (major version upgrade with breaking changes)
- **gunicorn**: 23.0.0 → 25.0.1 (WSGI server update)
- **packaging**: 25.0 → 26.0

### Notable Updates
- **boto3/botocore**: 1.42.25 → 1.42.40 (AWS SDK updates)
- **django-debug-toolbar**: 6.1.0 → 6.2.0 (development tooling)
- **ruff**: 0.14.11 → 0.14.14 (linter/formatter)
- **uv**: 0.9.24 → 0.9.28 (package installer)
- **coverage**: 7.13.1 → 7.13.2
- **faker**: 40.1.0 → 40.1.2
- **pillow-heif**: 1.1.1 → 1.2.0
- **numpy**: 2.4.1 → 2.4.2

### Dependency Cleanup
- Removed explicit `tzdata` requirement (now handled internally by pandas 3.0.0)

## Testing
- Run the test suite to ensure compatibility with updated dependencies
- Verify that pandas 3.0.0 doesn't introduce breaking changes in data processing code
- Test gunicorn 25.x compatibility in development and staging environments

## Migration Notes
The pandas 3.0.0 upgrade may include API changes. Review any code using pandas DataFrames for potential compatibility issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)