### PR TITLE
chore(deps): bump pillow, django, uv to patch security vulnerabilities

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,7 @@ defusedxml==0.7.1
     #   -c main.txt
     #   py-serializable
     #   willow
-django==6.0.3
+django==6.0.4
     # via
     #   -c main.txt
     #   django-debug-toolbar
@@ -212,7 +212,7 @@ urllib3==2.6.3
     # via
     #   -c main.txt
     #   requests
-uv==0.10.8
+uv==0.11.7
     # via -r dev.in
 wagtail==7.2.3
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -142,7 +142,7 @@ packaging==26.0
     #   pip-audit
     #   pip-requirements-parser
     #   pipdeptree
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c main.txt
     #   pillow-heif

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -32,7 +32,7 @@ dj-database-url==3.1.2
     # via -r main.in
 dj-static==0.0.6
     # via -r main.in
-django==6.0.3
+django==6.0.4
     # via
     #   -r main.in
     #   dj-database-url

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -117,7 +117,7 @@ packaging==26.0
     # via gunicorn
 pandas==3.0.1
     # via -r main.in
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   pillow-heif
     #   wagtail


### PR DESCRIPTION
## Summary

Patches Dependabot alert [#165](https://github.com/PythonIreland/website/security/dependabot/165) plus pre-existing `pip-audit` findings that were blocking CI:

- **pillow** `12.1.1 -> 12.2.0` — [GHSA-whj4-6x5x-4v2j](https://github.com/python-pillow/Pillow/security/advisories/GHSA-whj4-6x5x-4v2j) / CVE-2026-40192 (FITS GZIP decompression bomb, high)
- **django** `6.0.3 -> 6.0.4` — CVE-2026-33033, CVE-2026-33034, CVE-2026-4292, CVE-2026-4277, CVE-2026-3902
- **uv** `0.10.8 -> 0.11.7` — GHSA-pjjw-68hj-v9mw

Pins were edited directly instead of re-running `uv pip compile` to keep the diff minimal and avoid unrelated churn from local vs. CI uv-version differences.

## Test plan
- [ ] CI passes (lint + tests + pip-audit)
- [ ] Dependabot alert #165 auto-closes on merge