### PR TITLE
chore(deps): refresh locked dependencies for April 2026

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,42 +2,40 @@
 #    uv pip compile --output-file requirements/dev.txt requirements/dev.in
 anyascii==0.3.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 asgiref==3.11.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django
 beautifulsoup4==4.14.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 boolean-py==5.0
     # via license-expression
-cachecontrol[filecache]==0.14.4
-    # via
-    #   cachecontrol
-    #   pip-audit
+cachecontrol==0.14.4
+    # via pip-audit
 certifi==2026.2.25
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
-coverage==7.13.4
-    # via -r dev.in
-cyclonedx-python-lib==11.6.0
+coverage==7.13.5
+    # via -r requirements/dev.in
+cyclonedx-python-lib==11.7.0
     # via pip-audit
 defusedxml==0.7.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   py-serializable
     #   willow
 django==6.0.4
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django-debug-toolbar
     #   django-filter
     #   django-modelcluster
@@ -51,70 +49,70 @@ django==6.0.4
     #   model-mommy
     #   modelsearch
     #   wagtail
-django-debug-toolbar==6.2.0
-    # via -r dev.in
+django-debug-toolbar==6.3.0
+    # via -r requirements/dev.in
 django-filter==25.2
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 django-modelcluster==6.4.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 django-permissionedforms==0.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
-django-stubs-ext==5.2.9
+django-stubs-ext==6.0.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django-tasks
 django-taggit==6.1.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 django-tasks==0.9.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   modelsearch
     #   wagtail
 django-treebeard==4.8.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 draftjs-exporter==5.2.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 et-xmlfile==2.0.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   openpyxl
 factory-boy==3.3.3
     # via wagtail-factories
-faker==40.8.0
+faker==40.15.0
     # via factory-boy
-fakeredis==2.34.1
-    # via -r dev.in
-filelock==3.25.0
+fakeredis==2.35.1
+    # via -r requirements/dev.in
+filelock==3.29.0
     # via cachecontrol
 filetype==1.2.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   willow
-idna==3.11
+idna==3.12
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
 isort==8.0.1
-    # via -r dev.in
+    # via -r requirements/dev.in
 laces==0.1.2
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 license-expression==30.4.4
     # via cyclonedx-python-lib
@@ -123,43 +121,45 @@ markdown-it-py==4.0.0
 mdurl==0.1.2
     # via markdown-it-py
 model-mommy==2.0.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 modelsearch==1.1.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 msgpack==1.1.2
     # via cachecontrol
 openpyxl==3.1.5
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 packageurl-python==0.17.6
     # via cyclonedx-python-lib
-packaging==26.0
+packaging==26.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   pip-audit
     #   pip-requirements-parser
     #   pipdeptree
 pillow==12.2.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   pillow-heif
     #   wagtail
 pillow-heif==1.3.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   willow
+pip==26.0.1
+    # via pip-api
 pip-api==0.0.34
     # via pip-audit
 pip-audit==2.10.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 pip-requirements-parser==32.0.1
     # via pip-audit
-pipdeptree==2.31.0
-    # via -r dev.in
-platformdirs==4.9.2
+pipdeptree==2.35.1
+    # via -r requirements/dev.in
+platformdirs==4.9.6
     # via pip-audit
 py-serializable==2.1.0
     # via cyclonedx-python-lib
@@ -167,61 +167,60 @@ pygments==2.20.0
     # via rich
 pyparsing==3.3.2
     # via pip-requirements-parser
-redis==7.2.1
+redis==7.4.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   fakeredis
-requests==2.33.0
+requests==2.33.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   cachecontrol
     #   pip-audit
     #   wagtail
-rich==14.3.3
+rich==15.0.0
     # via pip-audit
-ruff==0.15.4
-    # via -r dev.in
+ruff==0.15.11
+    # via -r requirements/dev.in
 sortedcontainers==2.4.0
     # via
     #   cyclonedx-python-lib
     #   fakeredis
 soupsieve==2.8.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   beautifulsoup4
 sqlparse==0.5.5
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django
     #   django-debug-toolbar
 telepath==0.3.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
-tomli==2.4.0
+tomli==2.4.1
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
 typing-extensions==4.15.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   beautifulsoup4
     #   django-stubs-ext
     #   django-tasks
 urllib3==2.6.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
 uv==0.11.7
-    # via -r dev.in
+    # via -r requirements/dev.in
 wagtail==7.2.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail-factories
 wagtail-factories==4.4.0
-    # via -r dev.in
-willow[heif]==1.12.0
+    # via -r requirements/dev.in
+willow==1.12.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
-    #   willow

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -10,31 +10,31 @@ babel==2.18.0
     # via delorean
 beautifulsoup4==4.14.3
     # via wagtail
-boto3==1.42.61
-    # via -r main.in
-botocore==1.42.61
+boto3==1.42.92
+    # via -r requirements/main.in
+botocore==1.42.92
     # via
     #   boto3
     #   s3transfer
 certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
 colander==2.0
-    # via -r main.in
+    # via -r requirements/main.in
 defusedxml==0.7.1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   willow
 delorean==1.0.0
-    # via -r main.in
+    # via -r requirements/main.in
 dj-database-url==3.1.2
-    # via -r main.in
+    # via -r requirements/main.in
 dj-static==0.0.6
-    # via -r main.in
+    # via -r requirements/main.in
 django==6.0.4
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   dj-database-url
     #   django-appconf
     #   django-compressor
@@ -55,27 +55,27 @@ django-appconf==1.2.0
     # via django-compressor
 django-compressor==4.6.0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   django-libsass
 django-extensions==4.1
-    # via -r main.in
+    # via -r requirements/main.in
 django-filter==25.2
     # via wagtail
 django-libsass==0.9
-    # via -r main.in
+    # via -r requirements/main.in
 django-modelcluster==6.4.1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail
 django-permissionedforms==0.1
     # via wagtail
 django-storages==1.14.6
-    # via -r main.in
-django-stubs-ext==5.2.9
+    # via -r requirements/main.in
+django-stubs-ext==6.0.3
     # via django-tasks
 django-taggit==6.1.0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail
 django-tasks==0.9.0
     # via
@@ -83,7 +83,7 @@ django-tasks==0.9.0
     #   wagtail
 django-treebeard==4.8.0
     # via wagtail
-djangorestframework==3.16.1
+djangorestframework==3.17.1
     # via wagtail
 draftjs-exporter==5.2.0
     # via wagtail
@@ -91,11 +91,11 @@ et-xmlfile==2.0.0
     # via openpyxl
 filetype==1.2.0
     # via willow
-gunicorn==25.1.0
-    # via -r main.in
+gunicorn==25.3.0
+    # via -r requirements/main.in
 humanize==4.15.0
     # via delorean
-idna==3.11
+idna==3.12
     # via requests
 iso8601==2.1.0
     # via colander
@@ -109,45 +109,45 @@ libsass==0.23.0
     # via django-libsass
 modelsearch==1.1.1
     # via wagtail
-numpy==2.4.2
+numpy==2.4.4
     # via pandas
 openpyxl==3.1.5
     # via wagtail
-packaging==26.0
+packaging==26.1
     # via gunicorn
-pandas==3.0.1
-    # via -r main.in
+pandas==3.0.2
+    # via -r requirements/main.in
 pillow==12.2.0
     # via
     #   pillow-heif
     #   wagtail
 pillow-heif==1.3.0
     # via willow
-psycopg[binary]==3.3.3
-    # via -r main.in
+psycopg==3.3.3
+    # via -r requirements/main.in
 psycopg-binary==3.3.3
     # via psycopg
-pydantic==2.12.5
-    # via -r main.in
-pydantic-core==2.41.5
+pydantic==2.13.3
+    # via -r requirements/main.in
+pydantic-core==2.46.3
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   botocore
     #   delorean
     #   pandas
 pytz==2026.1.post1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   delorean
 rcssmin==1.2.2
     # via django-compressor
-redis==7.2.1
-    # via -r main.in
-requests==2.33.0
+redis==7.4.0
+    # via -r requirements/main.in
+requests==2.33.1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail
 rjsmin==1.2.5
     # via django-compressor
@@ -182,10 +182,10 @@ urllib3==2.6.3
     #   botocore
     #   requests
 wagtail==7.2.3
-    # via -r main.in
+    # via -r requirements/main.in
 whitenoise==6.12.0
-    # via -r main.in
-willow[heif]==1.12.0
+    # via -r requirements/main.in
+willow==1.12.0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail


### PR DESCRIPTION
## Summary

Routine refresh of the compiled `requirements/*.txt` lock files produced by `uv pip compile`. No `.in` files were touched — only pinned versions move.

## Runtime updates (`requirements/main.txt`)

| Package | From | To |
|---|---|---|
| boto3 / botocore | 1.42.61 | 1.42.92 |
| charset-normalizer | 3.4.4 | 3.4.7 |
| django-stubs-ext | 5.2.9 | 6.0.3 |
| djangorestframework | 3.16.1 | 3.17.1 |
| gunicorn | 25.1.0 | 25.3.0 |
| idna | 3.11 | 3.12 |
| numpy | 2.4.2 | 2.4.4 |
| packaging | 26.0 | 26.1 |
| pandas | 3.0.1 | 3.0.2 |
| pydantic | 2.12.5 | 2.13.3 |
| pydantic-core | 2.41.5 | 2.46.3 |

## Development updates (`requirements/dev.txt`)

| Package | From | To |
|---|---|---|
| django-debug-toolbar | 6.2.0 | 6.3.0 |
| redis | 7.2.1 | 7.4.0 |
| requests | 2.33.0 | 2.33.1 |
| rich | 14.3.3 | 15.0.0 |
| ruff | 0.15.4 | 0.15.11 |

## Notes

- The header `-r` / `-c` comments in both compiled files now use `requirements/<file>` paths, matching the output of `task dependencies:compute` when run from the repository root.
- The `[filecache]`, `[binary]` and `[heif]` markers no longer appear in the compiled output (newer uv formatting). The transitive sub-packages (`psycopg-binary`, `pillow-heif`) are still pulled in, so the installed set is identical.

## Test plan

- [x] `task dependencies:compute` produces no further diff
- [x] `task tests` passes
- [x] `task code:check` passes
- [ ] Local `task run` boots the site without import errors