### PR TITLE
chore(deps): refresh locked dependencies for late April 2026

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-python 3.13.11
-task 3.37.2
+python 3.13
+task   3.50.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ boolean-py==5.0
     # via license-expression
 cachecontrol==0.14.4
     # via pip-audit
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -c requirements/main.txt
     #   requests
@@ -104,7 +104,7 @@ filetype==1.2.0
     # via
     #   -c requirements/main.txt
     #   willow
-idna==3.12
+idna==3.13
     # via
     #   -c requirements/main.txt
     #   requests
@@ -134,7 +134,7 @@ openpyxl==3.1.5
     #   wagtail
 packageurl-python==0.17.6
     # via cyclonedx-python-lib
-packaging==26.1
+packaging==26.2
     # via
     #   -c requirements/main.txt
     #   pip-audit
@@ -149,7 +149,7 @@ pillow-heif==1.3.0
     # via
     #   -c requirements/main.txt
     #   willow
-pip==26.0.1
+pip==26.1
     # via pip-api
 pip-api==0.0.34
     # via pip-audit
@@ -179,7 +179,7 @@ requests==2.33.1
     #   wagtail
 rich==15.0.0
     # via pip-audit
-ruff==0.15.11
+ruff==0.15.12
     # via -r requirements/dev.in
 sortedcontainers==2.4.0
     # via
@@ -212,7 +212,7 @@ urllib3==2.6.3
     # via
     #   -c requirements/main.txt
     #   requests
-uv==0.11.7
+uv==0.11.8
     # via -r requirements/dev.in
 wagtail==7.2.3
     # via

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -10,13 +10,13 @@ babel==2.18.0
     # via delorean
 beautifulsoup4==4.14.3
     # via wagtail
-boto3==1.42.92
+boto3==1.42.97
     # via -r requirements/main.in
-botocore==1.42.92
+botocore==1.42.97
     # via
     #   boto3
     #   s3transfer
-certifi==2026.2.25
+certifi==2026.4.22
     # via requests
 charset-normalizer==3.4.7
     # via requests
@@ -95,7 +95,7 @@ gunicorn==25.3.0
     # via -r requirements/main.in
 humanize==4.15.0
     # via delorean
-idna==3.12
+idna==3.13
     # via requests
 iso8601==2.1.0
     # via colander
@@ -113,7 +113,7 @@ numpy==2.4.4
     # via pandas
 openpyxl==3.1.5
     # via wagtail
-packaging==26.1
+packaging==26.2
     # via gunicorn
 pandas==3.0.2
     # via -r requirements/main.in
@@ -151,7 +151,7 @@ requests==2.33.1
     #   wagtail
 rjsmin==1.2.5
     # via django-compressor
-s3transfer==0.16.0
+s3transfer==0.16.1
     # via boto3
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Summary

- Update certifi 2026.2.25 → 2026.4.22
- Update idna 3.12 → 3.13
- Update packaging 26.1 → 26.2
- Update ruff 0.15.11 → 0.15.12
- Update uv 0.11.7 → 0.11.8
- Update pip 26.0.1 → 26.1
- Update boto3/botocore 1.42.92 → 1.42.97
- Update s3transfer 0.16.0 → 0.16.1
- Update task 3.37.2 → 3.50.0 in .tool-versions

## Test plan

- [ ] Verify CI passes with updated dependencies
- [ ] Check no breaking changes in updated packages