### PR TITLE
chore(deps): bump urllib3 from 2.6.3 to 2.7.0 in /requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -208,7 +208,7 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   django-stubs-ext
     #   django-tasks
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c main.txt
     #   requests

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -177,7 +177,7 @@ typing-inspection==0.4.2
     # via pydantic
 tzlocal==5.3.1
     # via delorean
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
Bumps the transitive dependency `urllib3` from 2.6.3 to 2.7.0.

## Why
`pip-audit` (the "Check for security vulnerabilities" CI step) reports two known vulnerabilities in `urllib3==2.6.3`:

| Package | Version | ID | Fix |
|---|---|---|---|
| urllib3 | 2.6.3 | PYSEC-2026-141 | 2.7.0 |
| urllib3 | 2.6.3 | PYSEC-2026-142 | 2.7.0 |

This currently makes the security check fail on every open PR (including the Wagtail 7.3.2 bump #217). `urllib3` is a transitive dependency (via `requests`/`botocore`) and has no runtime dependencies of its own, so only the compiled pins in `requirements/main.txt` and `requirements/dev.txt` change.

Part of unblocking #217.