### PR TITLE
chore(deps): bump idna from 3.13 to 3.15 in /requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -106,7 +106,7 @@ filetype==1.2.0
     # via
     #   -c main.txt
     #   willow
-idna==3.13
+idna==3.15
     # via
     #   -c main.txt
     #   requests

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -95,7 +95,7 @@ gunicorn==25.3.0
     # via -r main.in
 humanize==4.15.0
     # via delorean
-idna==3.13
+idna==3.15
     # via requests
 iso8601==2.1.0
     # via colander


### PR DESCRIPTION
Bumps the transitive dependency `idna` from 3.13 to 3.15.

## Why
`pip-audit` (the "Check for security vulnerabilities" CI step) reports a known vulnerability in `idna==3.13`:

| Package | Version | ID | Fix |
|---|---|---|---|
| idna | 3.13 | CVE-2026-45409 | 3.15 |

This currently makes the security check fail on every open PR (including the Wagtail 7.3.2 bump #217). `idna` is a transitive dependency (via `requests`) with no runtime dependencies of its own, so only the compiled pins in `requirements/main.txt` and `requirements/dev.txt` change. `requests` requires `idna<4`, so 3.15 is compatible.

Part of unblocking #217.