### PR TITLE
chore(deps): upgrade Django to 6.0.6

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,42 +2,40 @@
 #    uv pip compile --output-file requirements/dev.txt requirements/dev.in
 anyascii==0.3.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 asgiref==3.11.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django
 beautifulsoup4==4.14.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 boolean-py==5.0
     # via license-expression
-cachecontrol[filecache]==0.14.4
-    # via
-    #   cachecontrol
-    #   pip-audit
+cachecontrol==0.14.4
+    # via pip-audit
 certifi==2026.4.22
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
 charset-normalizer==3.4.7
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
 coverage==7.13.5
-    # via -r dev.in
+    # via -r requirements/dev.in
 cyclonedx-python-lib==11.7.0
     # via pip-audit
 defusedxml==0.7.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   py-serializable
     #   willow
-django==6.0.5
+django==6.0.6
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django-debug-toolbar
     #   django-filter
     #   django-modelcluster
@@ -52,69 +50,69 @@ django==6.0.5
     #   modelsearch
     #   wagtail
 django-debug-toolbar==6.3.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 django-filter==25.2
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 django-modelcluster==6.4.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 django-permissionedforms==0.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 django-stubs-ext==6.0.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django-tasks
 django-taggit==6.1.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 django-tasks==0.9.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   modelsearch
     #   wagtail
 django-treebeard==4.8.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 djangorestframework==3.17.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 draftjs-exporter==5.2.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 et-xmlfile==2.0.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   openpyxl
 factory-boy==3.3.3
     # via wagtail-factories
 faker==40.15.0
     # via factory-boy
 fakeredis==2.35.1
-    # via -r dev.in
+    # via -r requirements/dev.in
 filelock==3.29.0
     # via cachecontrol
 filetype==1.2.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   willow
 idna==3.15
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
 isort==8.0.1
-    # via -r dev.in
+    # via -r requirements/dev.in
 laces==0.1.2
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 license-expression==30.4.4
     # via cyclonedx-python-lib
@@ -123,42 +121,44 @@ markdown-it-py==4.0.0
 mdurl==0.1.2
     # via markdown-it-py
 model-mommy==2.0.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 modelsearch==1.1.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 msgpack==1.1.2
     # via cachecontrol
 openpyxl==3.1.5
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 packageurl-python==0.17.6
     # via cyclonedx-python-lib
 packaging==26.2
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   pip-audit
     #   pip-requirements-parser
     #   pipdeptree
 pillow==12.2.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   pillow-heif
     #   wagtail
 pillow-heif==1.3.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   willow
+pip==26.1.2
+    # via pip-api
 pip-api==0.0.34
     # via pip-audit
 pip-audit==2.10.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 pip-requirements-parser==32.0.1
     # via pip-audit
 pipdeptree==2.35.1
-    # via -r dev.in
+    # via -r requirements/dev.in
 platformdirs==4.9.6
     # via pip-audit
 py-serializable==2.1.0
@@ -169,34 +169,34 @@ pyparsing==3.3.2
     # via pip-requirements-parser
 redis==7.4.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   fakeredis
 requests==2.33.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   cachecontrol
     #   pip-audit
     #   wagtail
 rich==15.0.0
     # via pip-audit
 ruff==0.15.12
-    # via -r dev.in
+    # via -r requirements/dev.in
 sortedcontainers==2.4.0
     # via
     #   cyclonedx-python-lib
     #   fakeredis
 soupsieve==2.8.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   beautifulsoup4
 sqlparse==0.5.5
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   django
     #   django-debug-toolbar
 telepath==0.3.1
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
 tomli==2.4.1
     # via pip-audit
@@ -204,24 +204,23 @@ tomli-w==1.2.0
     # via pip-audit
 typing-extensions==4.15.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   beautifulsoup4
     #   django-stubs-ext
     #   django-tasks
 urllib3==2.7.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   requests
 uv==0.11.15
-    # via -r dev.in
+    # via -r requirements/dev.in
 wagtail==7.2.3
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail-factories
 wagtail-factories==4.4.0
-    # via -r dev.in
-willow[heif]==1.12.0
+    # via -r requirements/dev.in
+willow==1.12.0
     # via
-    #   -c main.txt
+    #   -c requirements/main.txt
     #   wagtail
-    #   willow

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -11,7 +11,7 @@ babel==2.18.0
 beautifulsoup4==4.14.3
     # via wagtail
 boto3==1.42.97
-    # via -r main.in
+    # via -r requirements/main.in
 botocore==1.42.97
     # via
     #   boto3
@@ -21,20 +21,20 @@ certifi==2026.4.22
 charset-normalizer==3.4.7
     # via requests
 colander==2.0
-    # via -r main.in
+    # via -r requirements/main.in
 defusedxml==0.7.1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   willow
 delorean==1.0.0
-    # via -r main.in
+    # via -r requirements/main.in
 dj-database-url==3.1.2
-    # via -r main.in
+    # via -r requirements/main.in
 dj-static==0.0.6
-    # via -r main.in
-django==6.0.5
+    # via -r requirements/main.in
+django==6.0.6
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   dj-database-url
     #   django-appconf
     #   django-compressor
@@ -55,27 +55,27 @@ django-appconf==1.2.0
     # via django-compressor
 django-compressor==4.6.0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   django-libsass
 django-extensions==4.1
-    # via -r main.in
+    # via -r requirements/main.in
 django-filter==25.2
     # via wagtail
 django-libsass==0.9
-    # via -r main.in
+    # via -r requirements/main.in
 django-modelcluster==6.4.1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail
 django-permissionedforms==0.1
     # via wagtail
 django-storages==1.14.6
-    # via -r main.in
+    # via -r requirements/main.in
 django-stubs-ext==6.0.3
     # via django-tasks
 django-taggit==6.1.0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail
 django-tasks==0.9.0
     # via
@@ -92,7 +92,7 @@ et-xmlfile==2.0.0
 filetype==1.2.0
     # via willow
 gunicorn==25.3.0
-    # via -r main.in
+    # via -r requirements/main.in
 humanize==4.15.0
     # via delorean
 idna==3.15
@@ -116,38 +116,38 @@ openpyxl==3.1.5
 packaging==26.2
     # via gunicorn
 pandas==3.0.2
-    # via -r main.in
+    # via -r requirements/main.in
 pillow==12.2.0
     # via
     #   pillow-heif
     #   wagtail
 pillow-heif==1.3.0
     # via willow
-psycopg[binary]==3.3.3
-    # via -r main.in
+psycopg==3.3.3
+    # via -r requirements/main.in
 psycopg-binary==3.3.3
     # via psycopg
 pydantic==2.13.3
-    # via -r main.in
+    # via -r requirements/main.in
 pydantic-core==2.46.3
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   botocore
     #   delorean
     #   pandas
 pytz==2026.1.post1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   delorean
 rcssmin==1.2.2
     # via django-compressor
 redis==7.4.0
-    # via -r main.in
+    # via -r requirements/main.in
 requests==2.33.1
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail
 rjsmin==1.2.5
     # via django-compressor
@@ -182,10 +182,10 @@ urllib3==2.7.0
     #   botocore
     #   requests
 wagtail==7.2.3
-    # via -r main.in
+    # via -r requirements/main.in
 whitenoise==6.12.0
-    # via -r main.in
-willow[heif]==1.12.0
+    # via -r requirements/main.in
+willow==1.12.0
     # via
-    #   -r main.in
+    #   -r requirements/main.in
     #   wagtail


### PR DESCRIPTION
## Summary

Bumps Django from **6.0.5** to **6.0.6** (latest version compatible with the current Wagtail constraint).

## Changes

- `requirements/main.txt` & `requirements/dev.txt`: recompiled via `task dependencies:upgrade:django` (`--upgrade-package django`)

The only real version change is Django. The remaining diff is lock reformatting by the current `uv` version (extras expanded: `psycopg[binary]`→`psycopg`+`psycopg-binary`, `willow[heif]`→`willow`+`pillow-heif`; `pip` made explicit via `pip-api`), functionally equivalent.

## Validation

- ✅ Docker image rebuilt with Django 6.0.6
- ✅ 7/7 tests pass
- ✅ No new project migrations (`makemigrations --check`)