### PR TITLE
chore(deps): upgrade boto3 and AWS SDK

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -10,9 +10,9 @@ babel==2.18.0
     # via delorean
 beautifulsoup4==4.14.3
     # via wagtail
-boto3==1.42.97
+boto3==1.43.26
     # via -r requirements/main.in
-botocore==1.42.97
+botocore==1.43.26
     # via
     #   boto3
     #   s3transfer
@@ -151,7 +151,7 @@ requests==2.33.1
     #   wagtail
 rjsmin==1.2.5
     # via django-compressor
-s3transfer==0.16.1
+s3transfer==0.18.0
     # via boto3
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
Upgrades boto3 and its transitive dependencies (botocore, s3transfer) to their latest versions.