### PR TITLE
chore(deps): upgrade redis to v8

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -96,7 +96,7 @@ factory-boy==3.3.3
     # via wagtail-factories
 faker==40.15.0
     # via factory-boy
-fakeredis==2.35.1
+fakeredis==2.36.1
     # via -r requirements/dev.in
 filelock==3.29.0
     # via cachecontrol
@@ -167,7 +167,7 @@ pygments==2.20.0
     # via rich
 pyparsing==3.3.2
     # via pip-requirements-parser
-redis==7.4.0
+redis==8.0.0
     # via
     #   -c requirements/main.txt
     #   fakeredis

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -143,7 +143,7 @@ pytz==2026.1.post1
     #   delorean
 rcssmin==1.2.2
     # via django-compressor
-redis==7.4.0
+redis==8.0.0
     # via -r requirements/main.in
 requests==2.33.1
     # via


### PR DESCRIPTION
Upgrades the redis client from v7 to v8 (major version). Also upgrades fakeredis in dev dependencies to ensure compatibility.

⚠️ This is a major version bump — verify that the application works correctly with redis v8 API.