### PR TITLE
refactor(docker): slim multi-stage build, drop image size by ~58%

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Version control
+.git
+.gitignore
+
+# Python caches and virtualenvs
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+pythonie-venv/
+.venv/
+venv/
+
+# Local databases and media
+*.sqlite3
+pythonie/db.sqlite3
+media/
+
+# Secrets and local env
+.env
+.envrc
+*.env
+
+# Editor / OS noise
+.vscode/
+.idea/
+.DS_Store
+
+# Worktrees and tooling output
+.claude/
+graphify-out/
+
+# Docs and CI not needed in the build context
+*.md
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,52 @@
 # syntax=docker/dockerfile:1.21.0
-FROM python:3.13 AS compile-stage
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt update && \
-    apt install -y --no-install-recommends \
-        build-essential gcc neovim fish less iputils-ping postgresql-client \
-        ack
-ADD requirements/main.txt \
-    requirements/dev.txt \
-    requirements/production.txt \
-    ./requirements/
+
+# ---- builder: compile and install Python deps into an isolated venv ----
+FROM python:3.13-slim AS builder
+
+ENV UV_LINK_MODE=copy \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# build-essential/gcc are only needed to build wheels that lack a prebuilt one.
+# They live in this stage only and never reach the final image.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential gcc
+
 RUN --mount=type=cache,target=/root/.cache \
-    pip install -U pip uv ruff && \
-    python -m uv pip install \
+    pip install -U pip uv
+
+COPY requirements/main.txt \
+     requirements/dev.txt \
+     requirements/production.txt \
+     ./requirements/
+
+# Install everything into a self-contained venv at /opt/venv so the final
+# stage can copy it without dragging in the build toolchain.
+RUN --mount=type=cache,target=/root/.cache \
+    uv venv /opt/venv && \
+    uv pip install --python /opt/venv \
       -r requirements/main.txt \
       -r requirements/dev.txt \
-      -r requirements/production.txt aws
+      -r requirements/production.txt
 
-FROM compile-stage AS tests-stage
+# ---- dev: lean runtime image with interactive tooling (used by web + test) ----
+FROM python:3.13-slim AS dev
 
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Runtime-only system packages: the postgres client for psql/pg_dump plus the
+# interactive tooling the dev shell relies on (compose runs `fish`).
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        postgresql-client \
+        fish neovim less ack iputils-ping
+
+COPY --from=builder /opt/venv /opt/venv
+
+WORKDIR /app


### PR DESCRIPTION
## Summary

Reworks the `Dockerfile` into a real two-stage build and trims the image from **~1.69 GB to ~715 MB** (-58%).

### Changes
- **Real multi-stage**: a `builder` stage (`python:3.13-slim` + build toolchain) installs every requirement into an isolated venv at `/opt/venv`; the final `dev` stage (`python:3.13-slim`) copies only that venv plus runtime/interactive tooling. `build-essential`/`gcc` no longer ship in the final image.
- **Base image**: `python:3.13` → `python:3.13-slim`.
- **Drop the stray `aws` package** from the install line. It is an abandoned junk PyPI package, not the AWS CLI; `boto3` already provides the AWS SDK.
- **Stop reinstalling `ruff` via `pip -U`** — it is already pinned in `dev.txt`.
- `ADD` → `COPY` for the requirements files.
- apt cache mounts on `/var/lib/apt/lists` with `sharing=locked`.
- **New `.dockerignore`** to shrink the build context and keep `.env`/secrets out of it.

The final `dev` stage stays the last stage, so `docker build -t python.ie/website-dev .` (used by `task docker:build`, no `--target`) keeps producing the image consumed by both the `web` and `test` compose services.

### Validation
- `docker build` succeeds.
- Smoke tests inside the image: Python 3.13 from the venv, Django 6.0.6, Wagtail 7.3.2, redis client 8.0.0, boto3 1.43.26, fish 4.0.2, psql 17.10, ruff 0.15.16.
- `python pythonie/manage.py check --settings=pythonie.settings.tests` reports 0 issues with the source mounted.

Image size: **1.69 GB → 715 MB**.